### PR TITLE
Prepare for RedBase removal

### DIFF
--- a/azurechan/__init__.py
+++ b/azurechan/__init__.py
@@ -1,5 +1,5 @@
 from .azure_chan import AzureCog
 import redbot.core.bot as bots
 
-def setup(bot: bots.RedBase):
+def setup(bot: bots.Red):
     bot.add_cog(AzureCog())


### PR DESCRIPTION
Red is planning to remove RedBase from the core bot, as such importing RedBase will fail in the future.